### PR TITLE
Dfb 54 modify outputs route to create a line in the integrations table for each output that runs

### DIFF
--- a/designer/server/lib/outputs/s3fileupload.ts
+++ b/designer/server/lib/outputs/s3fileupload.ts
@@ -40,7 +40,6 @@ async function uploadFile(
       },
     })
       .then((res) => {
-        console.log("file res:", res);
         if (res.ok) {
           resolve({
             ok: true,
@@ -177,7 +176,6 @@ export const s3fileupload = async (
           } else {
             fileResponse.message = "No files were uploaded successfully.";
           }
-          console.log(fileResponse);
           resolve({ submission: submission });
         })
         .catch((err) => {

--- a/designer/server/plugins/routes/types/index.ts
+++ b/designer/server/plugins/routes/types/index.ts
@@ -1,5 +1,5 @@
-import { OutputRequest } from "./run-outputs";
+import { OutputRequest, IntegrationLog } from "./run-outputs";
 import { newConfigPayload } from "./new-config";
 import { submissionPayload } from "./save-submission";
 
-export { OutputRequest, newConfigPayload, submissionPayload };
+export { OutputRequest, newConfigPayload, submissionPayload, IntegrationLog };

--- a/designer/server/plugins/routes/types/run-outputs.ts
+++ b/designer/server/plugins/routes/types/run-outputs.ts
@@ -1,4 +1,8 @@
 import { FormDefinition } from "../../../../../model";
+import {
+  OutputConfiguration,
+  OutputType,
+} from "../../../../client/outputs/types";
 
 export interface OutputRequest {
   formScheme: FormDefinition;
@@ -8,4 +12,16 @@ export interface OutputRequest {
   files: Buffer | Buffer[];
   filenames: string | string[];
   fileTypes: string | string[];
+}
+
+export interface IntegrationLog {
+  integrationId?: string;
+  submissionId: string;
+  integrationName: string;
+  configuration: OutputConfiguration;
+  integrationType: OutputType;
+  request: {
+    [key: string]: any;
+  };
+  response?: any;
 }


### PR DESCRIPTION
# Description

Modified the outputs route so that now every integration that runs adds a row to the integration log. Each integration log contains the name of the integration, the associated submission, the configuration of the integration, the request that was sent to the handler, and the response from the integration.

- Added new IntegrationLog type
- once all integrations have finished, all integrations make a request to add a row to the dynamodb table

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
